### PR TITLE
Fix typo in README.me

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ cmake -DCMAKE_PREFIX_PATH=$QT_IOS_DIR \
 -DCMAKE_TOOLCHAIN_FILE=/path/to/ios.toolchain.cmake \
 -DPLATFORM=OS64COMBINED \
 -DENABLE_BITCODE=FALSE \
--G "XCode" \
+-G "Xcode" \
 path/to/Projet/
 ```
 


### PR DESCRIPTION
Currently, using `cmake` call example produces this error:
```
CMake Error: Could not create named generator XCode

Generators
* Unix Makefiles               = Generates standard UNIX makefiles.
  Ninja                        = Generates build.ninja files.
  Ninja Multi-Config           = Generates build-<Config>.ninja files.
  Xcode                        = Generate Xcode project files.
  CodeBlocks - Ninja           = Generates CodeBlocks project files.
  CodeBlocks - Unix Makefiles  = Generates CodeBlocks project files.
  CodeLite - Ninja             = Generates CodeLite project files.
  CodeLite - Unix Makefiles    = Generates CodeLite project files.
  Eclipse CDT4 - Ninja         = Generates Eclipse CDT 4.0 project files.
  Eclipse CDT4 - Unix Makefiles= Generates Eclipse CDT 4.0 project files.
  Kate - Ninja                 = Generates Kate project files.
  Kate - Unix Makefiles        = Generates Kate project files.
  Sublime Text 2 - Ninja       = Generates Sublime Text 2 project files.
  Sublime Text 2 - Unix Makefiles
                               = Generates Sublime Text 2 project files.
```
Update example to avoid error.