### PR TITLE
Allow specifying additional arguments for xcodebuild for the export archive step + README fixes

### DIFF
--- a/AddQtIosApp.cmake
+++ b/AddQtIosApp.cmake
@@ -600,6 +600,7 @@ function(add_qt_ios_app TARGET)
           -archivePath ${QT_IOS_TARGET_ARCHIVE_PATH}
           -exportOptionsPlist ${QT_IOS_EXPORT_OPTIONS_FILE}
           -exportPath ${QT_IOS_TARGET_IPA_PATH}
+          ${QT_IOS_EXPORT_ARCHIVE_XCODEBUILD_FLAGS}
         )
 
     endif()

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ add_qt_ios_app(MyApp
     CATALOG_APPICON "AppIcon"
     CATALOG_LAUNCHIMAGE "LaunchImage"
     ORIENTATION_PORTRAIT
-    ORIENTATION_PORTRAIT_UPSIDEDOWN
+    ORIENTATION_PORTRAIT_UPDOWN
     ORIENTATION_LANDSCAPE_LEFT
     ORIENTATION_LANDSCAPE_RIGHT
     PHOTO_LIBRARY_USAGE_DESCRIPTION "My App needs to access your photo library."
@@ -384,7 +384,7 @@ Set the Main Storyboard of your app. The file will also be bundled.
 The default allowed orientation can be set with flags:
 
 * `ORIENTATION_PORTRAIT`: Set *UIInterfaceOrientationPortrait* flag.
-* `ORIENTATION_PORTRAIT_UPSIDEDOWN`: Set *UIInterfaceOrientationPortraitUpSideDown* flag.
+* `ORIENTATION_PORTRAIT_UPDOWN`: Set *UIInterfaceOrientationPortraitUpSideDown* flag.
 * `ORIENTATION_LANDSCAPE_LEFT`: Set *UIInterfaceOrientationLandscapeLeft* flag.
 * `ORIENTATION_LANDSCAPE_RIGHT`: Set *UIInterfaceOrientationLandscapeRight* flag.
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ To sign your app you need at least a team id and a signing identity. I recommand
 * `QT_IOS_TEAM_ID`: Same as `TEAM_ID` option, can be useful to specify at configure time, not in source code.
 * `QT_IOS_CODE_SIGN_IDENTITY`: Same as `CODE_SIGN_IDENTITY` option, can be useful to specify at configure time, not in source code.
 * `QT_IOS_PROVISIONING_PROFILE_SPECIFIER`: Same as `PROVISIONING_PROFILE_SPECIFIER` option, can be useful to specify at configure time, not in source code.
+* `QT_IOS_EXPORT_ARCHIVE_XCODEBUILD_FLAGS`: Allows to specify additional flags that are passed to `xcodebuild` when creating the IPA file.
 
 Then you can simply build your app:
 


### PR DESCRIPTION
This change allows users to set the `QT_IOS_EXPORT_ARCHIVE_XCODEBUILD_FLAGS` variable. The content of this variable will be passed on as additional flags to the `xcodebuild` call during the export archive step. This allows e.g. using the `-allowProvisioningUpdates` flag in the build.

Additionally, I noticed that there was a minor inconsistency  in the README.md, which is also fixed via the change.