### PR TITLE
Allow passing additional args to xcodebuild archive

### DIFF
--- a/AddQtIosApp.cmake
+++ b/AddQtIosApp.cmake
@@ -557,6 +557,7 @@ function(add_qt_ios_app TARGET)
             -project ${PROJECT_BINARY_DIR}/${CMAKE_PROJECT_NAME}.xcodeproj
             -scheme ${QT_IOS_TARGET}
             -archivePath ${QT_IOS_TARGET_ARCHIVE_PATH}
+            ${QT_IOS_ARCHIVE_XCODEBUILD_FLAGS}
             archive
         )
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ To sign your app you need at least a team id and a signing identity. I recommand
 * `QT_IOS_TEAM_ID`: Same as `TEAM_ID` option, can be useful to specify at configure time, not in source code.
 * `QT_IOS_CODE_SIGN_IDENTITY`: Same as `CODE_SIGN_IDENTITY` option, can be useful to specify at configure time, not in source code.
 * `QT_IOS_PROVISIONING_PROFILE_SPECIFIER`: Same as `PROVISIONING_PROFILE_SPECIFIER` option, can be useful to specify at configure time, not in source code.
+* `QT_IOS_ARCHIVE_XCODEBUILD_FLAGS`: Allows to specify additional flags that are passed to `xcodebuild archive` when creating the archive file. 
 * `QT_IOS_EXPORT_ARCHIVE_XCODEBUILD_FLAGS`: Allows to specify additional flags that are passed to `xcodebuild` when creating the IPA file.
 
 Then you can simply build your app:


### PR DESCRIPTION
When creating the app archive, allow the user to pass
additional arguments by settings the QT_IOS_ARCHIVE_XCODEBUILD_FLAGS variable.
The flags in this variable will be appended to the xcodebuild archive
command.